### PR TITLE
Fix bug where 100% is sometimes displayed

### DIFF
--- a/XpBar/init.lua
+++ b/XpBar/init.lua
@@ -218,7 +218,7 @@ local DrawStuff = function()
         currLevelExp = nextMaxLevelexp - myExp
         levelProgress = 1
         if nextLevelexp ~= 0 then
-            levelProgress = thisLevelExp / nextLevelexp
+            levelProgress = math.floor(100 * (thisLevelExp / nextLevelexp)) / 100
         end
     end
 


### PR DESCRIPTION
While very near the next level, the progress % displays 100%. This floors the number to correctly display 99%, as 100% means (to me) that you should have leveled up.